### PR TITLE
Do not depend on ocl-icd

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -32,10 +32,6 @@ CMAKE_FLAGS+=" -DFFTW_INCLUDES=${PREFIX}/include/"
 CMAKE_FLAGS+=" -DFFTW_LIBRARY=${PREFIX}/lib/libfftw3f${SHLIB_EXT}"
 CMAKE_FLAGS+=" -DFFTW_THREADS_LIBRARY=${PREFIX}/lib/libfftw3f_threads${SHLIB_EXT}"
 
-# OpenCL ICD
-CMAKE_FLAGS+=" -DOPENCL_INCLUDE_DIR=${PREFIX}/include/"
-CMAKE_FLAGS+=" -DOPENCL_LIBRARY=${PREFIX}/lib/libOpenCL${SHLIB_EXT}"
-
 # Build in subdirectory and install.
 mkdir build
 cd build

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,15 @@
 {% set name = "openmm" %}
 {% set version = "7.4.0" %}
-{% set build = 5 %}
+{% set commit = "7a02c59b7f94c26c7996c2a0c4ef98d5fa4af7cd" %}
+{% set build = 7 %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://github.com/openmm/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: cb7ddd923d6f402cf2723b3c14509915abad328505e8ce401ac3131706dabeff
+  url: https://github.com/openmm/{{ name }}/archive/{{ commit }}.tar.gz
+  sha256: e2a2cf821a271c0107b3c813aec27700b1caf9f796c17eb41450c07f378de30e
 
 build:
   number: {{ build }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "openmm" %}
 {% set version = "7.4.0" %}
-{% set build = 4 %}
+{% set build = 5 %}
 
 package:
   name: {{ name }}
@@ -15,6 +15,7 @@ build:
   skip: True  # [py2k or win or (linux64 and cuda_compiler_version == "None")]
   missing_dso_whitelist:
   - "*/libcuda.*"  # [linux]
+  - "*/libOpenCL.*"  # [linux]
 
 requirements:
   build:
@@ -37,20 +38,20 @@ requirements:
     - doxygen 1.8.14
     # OpenCL ICD
     - ocl-icd  # [linux]
+    - ocl-icd-system # [linux]
     - khronos-opencl-icd-loader  # [osx or win]
+    - ocl_icd_wrapper_apple  # [osx]
 
   run:
     - python
     - fftw
     - numpy
-    # OpenCL ICD
-    - khronos-opencl-icd-loader  # [osx or win]
-    - ocl_icd_wrapper_apple  # [osx]
-    - ocl-icd  # [linux]
-    - ocl-icd-system  # [linux]
 
 test:
   requires:
+    - ocl-icd  # [linux]
+    - khronos-opencl-icd-loader  # [osx or win]
+    - ocl_icd_wrapper_apple  # [osx]
     - pocl  # [unix]
   imports:
     - simtk

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "openmm" %}
 {% set version = "7.4.0" %}
-{% set commit = "7a02c59b7f94c26c7996c2a0c4ef98d5fa4af7cd" %}
+{% set commit = "8ac164930170af8ff7460e448abb721b3ba526e7" %}
 {% set build = 7 %}
 
 package:
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://github.com/openmm/{{ name }}/archive/{{ commit }}.tar.gz
-  sha256: e2a2cf821a271c0107b3c813aec27700b1caf9f796c17eb41450c07f378de30e
+  sha256: 3df8f5d06c8261ba2a532647852f9abb745b554d013bfdd80e4e8d2b186c877e
 
 build:
   number: {{ build }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -75,7 +75,7 @@ test:
     - conda install -y ocl-icd && python -c "from simtk.openmm import Platform as P; n = P.getNumPlatforms(); assert n == 2, f'# platforms ({n}) != 2'"  # [linux]
     - conda install -y pocl  # [linux]
     - python -c "from simtk.openmm import Platform as P; n = P.getNumPlatforms(); assert n == 3, f'# platforms ({n}) != 3'"
-    - cd ${CONDA_PREFIX}/share/examples/openmm && python benchmark.py --test=rf --seconds=10 --platform=OpenCL; cd -
+    - cd ${CONDA_PREFIX}/share/openmm/examples && python benchmark.py --test=rf --seconds=10 --platform=OpenCL
 
 about:
   home: http://openmm.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,11 +49,6 @@ requirements:
     - numpy
 
 test:
-  requires:
-    - ocl-icd  # [linux]
-    - khronos-opencl-icd-loader  # [osx or win]
-    - ocl_icd_wrapper_apple  # [osx]
-    - pocl  # [unix]
   imports:
     - simtk
     - simtk.openmm
@@ -68,12 +63,24 @@ test:
     - if not exist %LIBRARY_LIB%/OpenMM.lib exit 1  # [win]
     - if not exist %LIBRARY_LIB%/plugins/OpenMMOpenCL.lib exit 1  # [win]
     - if not exist %LIBRARY_LIB%/plugins/OpenMMCPU.lib exit 1  # [win]
-    # We should see all four platforms in Linux, but CUDA is not recognized without a GPU
-    - python -c "from simtk.openmm import Platform as P; n = P.getNumPlatforms(); assert n == 3, f'# platforms ({n}) != 3'"
     # Debug silent errors in plugin loading
     - python -c "import simtk.openmm as mm; print(mm.Platform.getPluginLoadFailures())"
-    # Debug hardcoded library path
+    # Debug hardcoded library path (ripgrep issue: https://github.com/conda/conda-build/issues/3737)
     - python -c "import os, simtk.openmm.version as v; print(v.openmm_library_path); assert os.path.isdir(v.openmm_library_path), 'Directory does not exist'"
+    ## PLATFORM TESTING ##
+    # CUDA and OpenCL platforms will only be available if a device/implementation is available
+    # Linux:
+    #   There is no way to provide a CUDA device now, but we can install pocl for OpenCL in Linux
+    #   Without installing pocl, we will see Reference and CPU -> two platforms
+    #   Installing ocl-icd should have no effect
+    #   Only after installing pocl we will see the OpenCL platform
+    # MacOS:
+    #   The system OpenCL installation should be available without installing anything else
+    - python -c "from simtk.openmm import Platform as P; n = P.getNumPlatforms(); assert n == 2, f'# platforms ({n}) != 2'"  # [linux]
+    - conda install -y ocl-icd && python -c "from simtk.openmm import Platform as P; n = P.getNumPlatforms(); assert n == 2, f'# platforms ({n}) != 2'"  # [linux]
+    - conda install -y pocl  # [linux]
+    - python -c "from simtk.openmm import Platform as P; n = P.getNumPlatforms(); assert n == 3, f'# platforms ({n}) != 3'"
+    - cd ${CONDA_PREFIX}/share/examples/openmm && python benchmark.py --test=rf --seconds=10 --platform=OpenCL; cd -
 
 about:
   home: http://openmm.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - doxygen 1.8.14
     # OpenCL ICD
     - ocl-icd  # [linux]
-    - ocl-icd-system # [linux]
+    - ocl-icd-system  # [linux]
     - khronos-opencl-icd-loader  # [osx or win]
     - ocl_icd_wrapper_apple  # [osx]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,14 +69,20 @@ test:
     #   Without installing pocl, we will see Reference and CPU -> two platforms
     #   Installing ocl-icd should have no effect
     #   Only after installing pocl we will see the OpenCL platform
-    # MacOS:
-    #   The system OpenCL installation should be visible without installing anything else, but it won't
-    #   run a simulation because OpenMM does not support it.
     - python -c "from simtk.openmm import Platform as P; n = P.getNumPlatforms(); assert n == 2, f'Num platforms ({n}) != 2'"  # [linux]
-    - conda install -y ocl-icd && python -c "from simtk.openmm import Platform as P; n = P.getNumPlatforms(); assert n == 2, f'Num platforms ({n}) != 2'"  # [linux]
+    - conda install -y ocl-icd  # [linux]
+    - python -c "from simtk.openmm import Platform as P; n = P.getNumPlatforms(); assert n == 2, f'Num platforms ({n}) != 2'"  # [linux]
     - conda install -y pocl  # [linux]
-    - python -c "from simtk.openmm import Platform as P; n = P.getNumPlatforms(); assert n == 3, f'Num platforms ({n}) != 3'"
-    - cd ${CONDA_PREFIX}/share/openmm/examples && python benchmark.py --test=rf --seconds=10 --platform=OpenCL  # [linux]
+    - python -c "from simtk.openmm import Platform as P; n = P.getNumPlatforms(); assert n == 3, f'Num platforms ({n}) != 3'"  # [linux]
+    # MacOS:
+    #   System OpenCL will be visible but OpenMM does not support it. Without khronos-opencl-icd-loader, we will see three platforms.
+    #   Installing khronos-opencl-icd-loader + pocl should not cause problems.
+    - python -c "from simtk.openmm import Platform as P; n = P.getNumPlatforms(); assert n == 3, f'Num platforms ({n}) != 3'"  # [osx]
+    - conda install -y khronos-opencl-icd-loader pocl  # [osx]
+    - python -c "from simtk.openmm import Platform as P; n = P.getNumPlatforms(); assert n == 3, f'Num platforms ({n}) != 3'"  # [osx]
+    # Both should be able to run this now:
+    - python -c "import simtk.openmm as mm; print(mm.Platform.getPluginLoadFailures())" # [unix]
+    - cd ${CONDA_PREFIX}/share/openmm/examples && python benchmark.py --test=rf --seconds=10 --platform=OpenCL  # [unix]
 
 about:
   home: http://openmm.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
   skip: True  # [py2k or win or (linux64 and cuda_compiler_version == "None")]
   missing_dso_whitelist:
   - "*/libcuda.*"  # [linux]
-  - "*/libOpenCL.*"  # [linux]
+  - "*/libOpenCL.*"  # [unix]
 
 requirements:
   build:
@@ -37,11 +37,6 @@ requirements:
     - cython
     # needed for Python wrappers
     - doxygen 1.8.14
-    # OpenCL ICD
-    - ocl-icd  # [linux]
-    - ocl-icd-system  # [linux]
-    - khronos-opencl-icd-loader  # [osx or win]
-    - ocl_icd_wrapper_apple  # [osx]
 
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,12 +70,13 @@ test:
     #   Installing ocl-icd should have no effect
     #   Only after installing pocl we will see the OpenCL platform
     # MacOS:
-    #   The system OpenCL installation should be available without installing anything else
-    - python -c "from simtk.openmm import Platform as P; n = P.getNumPlatforms(); assert n == 2, f'# platforms ({n}) != 2'"  # [linux]
-    - conda install -y ocl-icd && python -c "from simtk.openmm import Platform as P; n = P.getNumPlatforms(); assert n == 2, f'# platforms ({n}) != 2'"  # [linux]
+    #   The system OpenCL installation should be visible without installing anything else, but it won't
+    #   run a simulation because OpenMM does not support it.
+    - python -c "from simtk.openmm import Platform as P; n = P.getNumPlatforms(); assert n == 2, f'Num platforms ({n}) != 2'"  # [linux]
+    - conda install -y ocl-icd && python -c "from simtk.openmm import Platform as P; n = P.getNumPlatforms(); assert n == 2, f'Num platforms ({n}) != 2'"  # [linux]
     - conda install -y pocl  # [linux]
-    - python -c "from simtk.openmm import Platform as P; n = P.getNumPlatforms(); assert n == 3, f'# platforms ({n}) != 3'"
-    - cd ${CONDA_PREFIX}/share/openmm/examples && python benchmark.py --test=rf --seconds=10 --platform=OpenCL
+    - python -c "from simtk.openmm import Platform as P; n = P.getNumPlatforms(); assert n == 3, f'Num platforms ({n}) != 3'"
+    - cd ${CONDA_PREFIX}/share/openmm/examples && python benchmark.py --test=rf --seconds=10 --platform=OpenCL  # [linux]
 
 about:
   home: http://openmm.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -81,7 +81,7 @@ test:
     - conda install -y khronos-opencl-icd-loader pocl  # [osx]
     - python -c "from simtk.openmm import Platform as P; n = P.getNumPlatforms(); assert n == 3, f'Num platforms ({n}) != 3'"  # [osx]
     # Both should be able to run this now:
-    - python -c "import simtk.openmm as mm; print(mm.Platform.getPluginLoadFailures())" # [unix]
+    - python -c "import simtk.openmm as mm; print(mm.Platform.getPluginLoadFailures())"  # [unix]
     - cd ${CONDA_PREFIX}/share/openmm/examples && python benchmark.py --test=rf --seconds=10 --platform=OpenCL  # [unix]
 
 about:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

After conversations had in https://github.com/openmm/openmm/issues/2401, we would like to make this decision and remove `ocl-icd` as a dependency because it has the potential to degrade OpenMM performance. 

While OpenMM supports OpenCL execution (in addition to CUDA), OpenMM also provides its own CPU-optimized implementation to fall back on should neither OpenCL nor CUDA be available. The OpenCL implementation is intended to achieve high performance on vendor-provided optimized OpenCL implementations (GPU, mainly) that should be available if the corresponding hardware + drivers are also available, but we feel that---at this time---the fall-back OpenMM-provided CPU platform should be used if vendor-provided OpenCL implementations are not available.

Given the way `openmm` recognizes and loads platforms, adding `ocl-icd` would also mean that an OpenCL CPU implementation would have precedence over the builtin `CPU` platform. Since `openmm` has only tested---and currently only offers validated support for--- Nvidia, AMD and Intel OpenCL implementations (none of them installable through `conda-forge`), this could result in untested installations that might end up providing wrong results.

As `openmm` knows how to discover the system OpenCL installation on its own, there is no technical reason or need to require `ocl-icd`. It would only offer a potential source of errors and maintenance burden. Also, if a different OpenCL implementation needs to be used, the user can always install `ocl-icd` together with `pocl` or similar libraries. We are open to test the performance of this approach in the future.

We hope our vision can fit in the wonderful `conda-forge` ecosystem, for which we are thankful and delighted to be a part of!

(Pinging @isuruf and @jakirkham for feedback).
