### PR TITLE
Add additional license files that had been accidentally omitted

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "openmm" %}
 {% set version = "7.4.0" %}
-{% set build = 5 %}
+{% set build = 6 %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -75,8 +75,8 @@ test:
 
 about:
   home: http://openmm.org
-  license: MIT
-  license_family: MIT
+  license: LGPL-3.0-or-later
+  license_family: LGPL
   license_file:
     - docs-source/licenses/Licenses.txt
     - docs-source/licenses/LGPL.txt
@@ -89,7 +89,8 @@ about:
     from your own code. It provides a combination of extreme flexibility
     (through custom forces and integrators), openness, and high performance
     (especially on recent GPUs) that make it truly unique among simulation
-    codes.
+    codes. OpenMM is MIT licensed with some LGPL portions (CUDA and OpenCL
+    platforms).
   doc_url: http://docs.openmm.org
   dev_url: https://github.com/openmm/openmm
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "openmm" %}
 {% set version = "7.4.0" %}
-{% set build = 4 %}
+{% set build = 5 %}
 
 package:
   name: {{ name }}
@@ -77,7 +77,10 @@ about:
   home: http://openmm.org
   license: MIT
   license_family: MIT
-  license_file: docs-source/licenses/Licenses.txt
+  license_file:
+    - docs-source/licenses/Licenses.txt
+    - docs-source/licenses/LGPL.txt
+    - docs-source/licenses/GPL.txt
   summary: 'A high performance toolkit for molecular simulation.'
 
   description: |


### PR DESCRIPTION
Addresses https://github.com/conda-forge/openmm-feedstock/pull/10#issuecomment-544351862 (accidentally omitted license files).

This PR adds the LGPL and GPL license text that applies to some components of the CUDA and OpenCL platforms.

Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

(Re-opening from a fork after @isuruf pointed out this is the correct conda-forge workflow.)