### PR TITLE
Build with and without ICD loaders

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,6 @@
-channel_targets:
-- conda-forge testing
+opencl_impl:
+  - icdloader
+  - icdsystem
+# cuda_impl:
+#   - cudatoolkit
+#   - systemcuda

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,12 @@ source:
 
 build:
   number: {{ build }}
-  skip: true  # [py2k or win or (linux64 and cuda_compiler_version == "None")]
+  string: py{{ PY_VER.replace(".", "") }}h{{ PKG_HASH }}_{{ opencl_impl }}_{{ build }}
+  skip: true  # [win or cuda_compiler_version != '10.2' or (not py37)]
   missing_dso_whitelist:
     - '*/libcuda.*'  # [linux]
+  script_env:
+    - opencl_impl
 
 requirements:
   build:
@@ -35,23 +38,23 @@ requirements:
     - cython
     # needed for Python wrappers
     - doxygen 1.8.14
-    # OpenCL ICD
-    - ocl-icd  # [linux]
-    - khronos-opencl-icd-loader  # [osx or win]
+    # OpenCL ICD loader
+    - ocl-icd  # [linux and (opencl_impl == "icdloader")]
+    - khronos-opencl-icd-loader  # [(osx or win) and (opencl_impl == "icdloader")]
 
   run:
     - python
     - fftw
     - numpy
-    # OpenCL ICD
-    - khronos-opencl-icd-loader  # [osx or win]
-    - ocl_icd_wrapper_apple  # [osx]
-    - ocl-icd  # [linux]
-    - ocl-icd-system  # [linux]
+    # OpenCL ICD loader
+    - khronos-opencl-icd-loader  # [(osx or win) and (opencl_impl == "icdloader")]
+    - ocl_icd_wrapper_apple  # [(osx) and (opencl_impl == "icdloader")]
+    - ocl-icd  # [(linux) and (opencl_impl == "icdloader")]
+    - ocl-icd-system  # [(linux) and (opencl_impl == "icdloader")]
 
 test:
   requires:
-    - pocl  # [unix]
+    - pocl  # [unix and (opencl_impl == "icdloader")]
   imports:
     - simtk
     - simtk.openmm


### PR DESCRIPTION
# Experiments with OpenCL ICD loaders

Trying to understand the complexities behind OpenCL ICD loaders and how this affects environments with mixed linking strategies.

## Description

In contrast with CUDA, where Nvidia governs the full pipeline, when it comes to OpenCL, there are multiple implementations available, provided by different vendors, organizations and projects. These implementations are called ICDs. When it comes to using one (or more) of them in an application, the developer might face the decision of linking against one specific ICD. What if the project wants to support several implementations? Here's where the loader can help: it provides a unified interface to all the possible ICDs present in the system, so the projects can link to the loader and forget about generating all the possible variants.

However, problems might arise if both strategies are used by different pacakges that are loaded in the same process. For example, a Python script is using a packaged linked against the loader, _and_ another package that links against the ICD directly. For this reason, Conda Forge requires to link against the ICD loader so packages within conda-forge are compatible. 

This can cause problems with packages _outside_ conda-forge, though.

## Packages available on conda-forge

Following `conda-forge` recommendations, packages are expected to link to the ICD loader:

* On Linux, the loader is provided by `ocl-icd`. By default, the loader will only see ICDs present in the conda environment. If system's ICDs are needed (e.g. Nvidia's), you can also install `ocl-icd-system` to symlink the system locations and make them visible.
* On MacOS and Windows, the loader is provided by `khronos-opencl-icd-loader`.
* MacOS also provides Apple's own implementation, not natively compatible with the loader mechanism. A wrapper is available to expose it as such: `ocl_icd_wrapper_apple`. This wrapper is not needed for other vendors.

### Scenario A: using the loader

TBD

### Scenario B: linking against Nvidia's OpenCL

TBD

### Scenario C: linking against Apple's OpenCL (MacOS only)

TBD
