### PR TITLE
Add OpenCL variants on MacOS

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,17 +8,29 @@ jobs:
     vmImage: macOS-10.15
   strategy:
     matrix:
-      osx_64_numpy1.16python3.6.____cpython:
-        CONFIG: osx_64_numpy1.16python3.6.____cpython
+      osx_64_numpy1.16opencl_implapplepython3.6.____cpython:
+        CONFIG: osx_64_numpy1.16opencl_implapplepython3.6.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_64_numpy1.16python3.7.____cpython:
-        CONFIG: osx_64_numpy1.16python3.7.____cpython
+      osx_64_numpy1.16opencl_implapplepython3.7.____cpython:
+        CONFIG: osx_64_numpy1.16opencl_implapplepython3.7.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_64_numpy1.16python3.8.____cpython:
-        CONFIG: osx_64_numpy1.16python3.8.____cpython
+      osx_64_numpy1.16opencl_implapplepython3.8.____cpython:
+        CONFIG: osx_64_numpy1.16opencl_implapplepython3.8.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_64_numpy1.19python3.9.____cpython:
-        CONFIG: osx_64_numpy1.19python3.9.____cpython
+      osx_64_numpy1.16opencl_implkhronospython3.6.____cpython:
+        CONFIG: osx_64_numpy1.16opencl_implkhronospython3.6.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_numpy1.16opencl_implkhronospython3.7.____cpython:
+        CONFIG: osx_64_numpy1.16opencl_implkhronospython3.7.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_numpy1.16opencl_implkhronospython3.8.____cpython:
+        CONFIG: osx_64_numpy1.16opencl_implkhronospython3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_numpy1.19opencl_implapplepython3.9.____cpython:
+        CONFIG: osx_64_numpy1.19opencl_implapplepython3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_numpy1.19opencl_implkhronospython3.9.____cpython:
+        CONFIG: osx_64_numpy1.19opencl_implkhronospython3.9.____cpython
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 

--- a/.ci_support/osx_64_numpy1.16opencl_implapplepython3.6.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.16opencl_implapplepython3.6.____cpython.yaml
@@ -20,6 +20,8 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
 - '1.16'
+opencl_impl:
+- apple
 pin_run_as_build:
   fftw:
     max_pin: x
@@ -27,7 +29,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.7.* *_cpython
+- 3.6.* *_cpython
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_numpy1.16opencl_implapplepython3.7.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.16opencl_implapplepython3.7.____cpython.yaml
@@ -19,7 +19,9 @@ fftw:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
-- '1.19'
+- '1.16'
+opencl_impl:
+- apple
 pin_run_as_build:
   fftw:
     max_pin: x
@@ -27,7 +29,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.7.* *_cpython
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_numpy1.16opencl_implapplepython3.8.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.16opencl_implapplepython3.8.____cpython.yaml
@@ -1,0 +1,39 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge test
+cuda_compiler_version:
+- None
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+fftw:
+- '3'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+numpy:
+- '1.16'
+opencl_impl:
+- apple
+pin_run_as_build:
+  fftw:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/osx_64_numpy1.16opencl_implkhronospython3.6.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.16opencl_implkhronospython3.6.____cpython.yaml
@@ -20,6 +20,8 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
 - '1.16'
+opencl_impl:
+- khronos
 pin_run_as_build:
   fftw:
     max_pin: x
@@ -27,7 +29,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.6.* *_cpython
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_numpy1.16opencl_implkhronospython3.7.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.16opencl_implkhronospython3.7.____cpython.yaml
@@ -20,6 +20,8 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
 - '1.16'
+opencl_impl:
+- khronos
 pin_run_as_build:
   fftw:
     max_pin: x
@@ -27,7 +29,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.6.* *_cpython
+- 3.7.* *_cpython
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_numpy1.16opencl_implkhronospython3.8.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.16opencl_implkhronospython3.8.____cpython.yaml
@@ -1,0 +1,39 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge test
+cuda_compiler_version:
+- None
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+fftw:
+- '3'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+numpy:
+- '1.16'
+opencl_impl:
+- khronos
+pin_run_as_build:
+  fftw:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/osx_64_numpy1.19opencl_implapplepython3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.19opencl_implapplepython3.9.____cpython.yaml
@@ -1,0 +1,39 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge test
+cuda_compiler_version:
+- None
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+fftw:
+- '3'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+numpy:
+- '1.19'
+opencl_impl:
+- apple
+pin_run_as_build:
+  fftw:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/osx_64_numpy1.19opencl_implkhronospython3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.19opencl_implkhronospython3.9.____cpython.yaml
@@ -1,0 +1,39 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge test
+cuda_compiler_version:
+- None
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+fftw:
+- '3'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+numpy:
+- '1.19'
+opencl_impl:
+- khronos
+pin_run_as_build:
+  fftw:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/README.md
+++ b/README.md
@@ -215,31 +215,59 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.16python3.6.____cpython</td>
+              <td>osx_64_numpy1.16opencl_implapplepython3.6.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8065&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmm-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.16python3.6.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmm-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.16opencl_implapplepython3.6.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.16python3.7.____cpython</td>
+              <td>osx_64_numpy1.16opencl_implapplepython3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8065&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmm-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.16python3.7.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmm-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.16opencl_implapplepython3.7.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.16python3.8.____cpython</td>
+              <td>osx_64_numpy1.16opencl_implapplepython3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8065&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmm-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.16python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmm-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.16opencl_implapplepython3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.19python3.9.____cpython</td>
+              <td>osx_64_numpy1.16opencl_implkhronospython3.6.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8065&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmm-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.19python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmm-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.16opencl_implkhronospython3.6.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_numpy1.16opencl_implkhronospython3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8065&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmm-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.16opencl_implkhronospython3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_numpy1.16opencl_implkhronospython3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8065&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmm-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.16opencl_implkhronospython3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_numpy1.19opencl_implapplepython3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8065&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmm-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.19opencl_implapplepython3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_numpy1.19opencl_implkhronospython3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8065&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmm-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.19opencl_implkhronospython3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -33,12 +33,15 @@ elif [[ "$target_platform" == osx* ]]; then
     CMAKE_FLAGS+=" -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
     CMAKE_FLAGS+=" -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}"
     if [[ "$opencl_impl" == khronos ]]; then
-        OPENCL_HOME="${PREFIX}"
-        CMAKE_FLAGS+=" -DOPENCL_INCLUDE_DIR=${OPENCL_HOME}/include"
-        CMAKE_FLAGS+=" -DOPENCL_LIBRARY=${OPENCL_HOME}/lib/libOpenCL${SHLIB_EXT}"
-    else
-        OPENCL_HOME="/System/Library/Frameworks/OpenCL.framework/OpenCL"
+        CMAKE_FLAGS+=" -DOPENCL_INCLUDE_DIR=${PREFIX}/include"
+        CMAKE_FLAGS+=" -DOPENCL_LIBRARY=${PREFIX}/lib/libOpenCL${SHLIB_EXT}"
     fi
+    # When using opencl_impl == apple, CMake will auto-locate it, so no need to provide the flags
+    # On Conda Forge, this will result in:
+    #   /Applications/Xcode_12.app/Contents/Developer/Platforms/MacOSX.platform/Developer/...
+    #   ...SDKs/MacOSX10.9.sdk/System/Library/Frameworks/OpenCL.framework
+    # On local builds, it might be:
+    #   /System/Library/Frameworks/OpenCL.framework/OpenCL
 fi
 
 # Set location for FFTW3 on both linux and mac

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -32,10 +32,13 @@ elif [[ "$target_platform" == osx* ]]; then
     CMAKE_FLAGS+=" -DCMAKE_OSX_SYSROOT=${CONDA_BUILD_SYSROOT}"
     CMAKE_FLAGS+=" -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
     CMAKE_FLAGS+=" -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}"
-    # # OpenCL, here just for completeness -- CMake should find it automatically
-    # OPENCL_HOME="/System/Library/Frameworks/OpenCL.framework/OpenCL"
-    # CMAKE_FLAGS+=" -DOPENCL_INCLUDE_DIR=${OPENCL_HOME}/include"
-    # CMAKE_FLAGS+=" -DOPENCL_LIBRARY=${OPENCL_HOME}/lib/libOpenCL${SHLIB_EXT}"
+    if [[ "$opencl_impl" == khronos ]]; then
+        OPENCL_HOME="${PREFIX}"
+    else
+        OPENCL_HOME="/System/Library/Frameworks/OpenCL.framework/OpenCL"
+    fi
+    CMAKE_FLAGS+=" -DOPENCL_INCLUDE_DIR=${OPENCL_HOME}/include"
+    CMAKE_FLAGS+=" -DOPENCL_LIBRARY=${OPENCL_HOME}/lib/libOpenCL${SHLIB_EXT}"
 fi
 
 # Set location for FFTW3 on both linux and mac
@@ -51,7 +54,7 @@ make -j$CPU_COUNT
 make -j$CPU_COUNT install PythonInstall
 
 # Put examples into an appropriate subdirectory.
-mkdir $PREFIX/share/openmm/
+mkdir -p $PREFIX/share/openmm/
 mv $PREFIX/examples $PREFIX/share/openmm/
 
 # Fix some overlinking warnings/errors

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -34,11 +34,11 @@ elif [[ "$target_platform" == osx* ]]; then
     CMAKE_FLAGS+=" -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}"
     if [[ "$opencl_impl" == khronos ]]; then
         OPENCL_HOME="${PREFIX}"
+        CMAKE_FLAGS+=" -DOPENCL_INCLUDE_DIR=${OPENCL_HOME}/include"
+        CMAKE_FLAGS+=" -DOPENCL_LIBRARY=${OPENCL_HOME}/lib/libOpenCL${SHLIB_EXT}"
     else
         OPENCL_HOME="/System/Library/Frameworks/OpenCL.framework/OpenCL"
     fi
-    CMAKE_FLAGS+=" -DOPENCL_INCLUDE_DIR=${OPENCL_HOME}/include"
-    CMAKE_FLAGS+=" -DOPENCL_LIBRARY=${OPENCL_HOME}/lib/libOpenCL${SHLIB_EXT}"
 fi
 
 # Set location for FFTW3 on both linux and mac

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,5 @@
 channel_targets:
 - conda-forge test
+opencl_impl:  # [osx]
+- apple  # [osx]
+- khronos  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,12 +8,12 @@ package:
 
 source:
   # pre-rc
-  url: https://github.com/openmm/{{ name }}/archive/2c36e9b34d046f09be4887ff60e7fdac02cf3cdb.tar.gz
-  sha256: 193a501d10ca713443e44e0d8972c5d3f30ee0ed116d59679d1cbdabd6b96b28
+  url: https://github.com/openmm/{{ name }}/archive/b49b82efb5a253a7c891ca084b3370e181de2ea3.tar.gz
+  sha256: 5bd813eecbcc819c7406a78bfb074020e975a0cc52b4f4734cd1eae92a1bd086
 
 build:
   number: {{ build }}
-  string: "py{{ PY_VER }}h{{ PKG_HASH }}_{{ build }}_{{ opencl_impl }}"  # [osx]
+  string: "py{{ PY_VER.replace('.', '') }}h{{ PKG_HASH }}_{{ build }}_{{ opencl_impl }}"  # [osx]
   track_features:  # make khronos low priority
     - openmm_opencl_khronos  # [osx and (opencl_impl == 'khronos')]
   skip: true  # [(cuda_compiler_version in (undefined, 'None') and (linux64 or win)) or ((cuda_compiler_version != '10.2') and (ppc64le))]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "openmm" %}
 {% set version = "7.5.0" %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 package:
   name: {{ name }}
@@ -13,7 +13,8 @@ source:
 
 build:
   number: {{ build }}
-  skip: true  # [((cuda_compiler_version == "None") and (linux64 or win)) or ((cuda_compiler_version != "10.2") and (ppc64le))]
+  string: "py{{ PY_VER }}h{{ PKG_HASH }}_{{ build }}_{{ opencl_impl }}"  # [osx]
+  skip: true  # [(cuda_compiler_version in (undefined, 'None') and (linux64 or win)) or ((cuda_compiler_version != '10.2') and (ppc64le))]
   missing_dso_whitelist:
     - "*/libcuda.*"    # [linux64 or ppc64le]
     - "*/libOpenCL.*"  # [unix]
@@ -41,7 +42,7 @@ requirements:
     - doxygen 1.8.14
     # OpenCL ICD
     - ocl-icd  # [linux]
-    - khronos-opencl-icd-loader  # [win]
+    - khronos-opencl-icd-loader  # [win or (osx and opencl_impl == 'khronos')]
 
   run:
     - python
@@ -50,7 +51,12 @@ requirements:
     # OpenCL ICD
     - ocl-icd  # [linux]
     - ocl-icd-system  # [linux]
-    - khronos-opencl-icd-loader  # [win]
+    - khronos-opencl-icd-loader  # [win or (osx and opencl_impl == 'khronos')]
+    - ocl_icd_wrapper_apple      # [osx and opencl_impl == 'khronos']
+
+  run_constrained:
+    - khronos-opencl-icd-loader  ==9999999999  # [osx and opencl_impl == 'apple']
+    - ocl_icd_wrapper_apple      ==9999999999  # [osx and opencl_impl == 'apple']
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,8 @@ source:
 build:
   number: {{ build }}
   string: "py{{ PY_VER }}h{{ PKG_HASH }}_{{ build }}_{{ opencl_impl }}"  # [osx]
+  track_features:  # make khronos low priority
+    - openmm_opencl_khronos  # [osx and (opencl_impl == 'khronos')]
   skip: true  # [(cuda_compiler_version in (undefined, 'None') and (linux64 or win)) or ((cuda_compiler_version != '10.2') and (ppc64le))]
   missing_dso_whitelist:
     - "*/libcuda.*"    # [linux64 or ppc64le]


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->


## Checks

- [ ] If unspecified, default package should be `opencl_impl == apple`
- [ ] When installing another package that uses OpenCL on the same env, Conda should install the variant `opencl_impl == khronos` (for new and existing environments)
- [ ] User can select variants using the build string `openmm=*=*apple*` or `openmm=*=*khronos*`